### PR TITLE
FEATURE: Flow 5.3 compatibility

### DIFF
--- a/Classes/Http/RedirectComponent.php
+++ b/Classes/Http/RedirectComponent.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+namespace Yeebase\TwoFactorAuthentication\Http;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\Component\ComponentChain;
+use Neos\Flow\Http\Component\ComponentContext;
+use Neos\Flow\Http\Component\ComponentInterface;
+use Neos\Flow\Http\Request as HttpRequest;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\Routing\UriBuilder;
+
+/**
+ * A HTTP component that redirects to the configured 2FA login/setup routes if requested
+ */
+final class RedirectComponent implements ComponentInterface
+{
+    public const REDIRECT_LOGIN = 'login';
+    public const REDIRECT_SETUP = 'setup';
+
+    /**
+     * @Flow\InjectConfiguration(path="routes.login")
+     * @var array
+     */
+    protected $loginRouteValues;
+
+    /**
+     * @Flow\InjectConfiguration(path="routes.setup")
+     * @var array
+     */
+    protected $setupRouteValue;
+
+    public function handle(ComponentContext $componentContext)
+    {
+        $redirectTarget = $componentContext->getParameter(static::class, 'redirect');
+        if ($redirectTarget === null) {
+            return;
+        }
+        if ($redirectTarget === self::REDIRECT_LOGIN) {
+            $this->redirectToLogin($componentContext);
+        } elseif ($redirectTarget === self::REDIRECT_SETUP) {
+            $this->redirectToSetup($componentContext);
+        } else {
+            throw new \RuntimeException(sprintf('Invalid redirect target "%s"', $redirectTarget), 1568189192);
+        }
+    }
+
+    /**
+     * Triggers a redirect to the 2FA login route configured at routes.login or throws an exception if the configuration is missing/incorrect
+     */
+    private function redirectToLogin(ComponentContext $componentContext): void
+    {
+        try {
+            $this->validateRouteValues($this->loginRouteValues);
+        } catch (\InvalidArgumentException $exception) {
+            throw new \RuntimeException('Missing/invalid routes.login configuration: ' . $exception->getMessage(), 1550660144, $exception);
+        }
+        $this->redirect($componentContext, $this->loginRouteValues);
+    }
+
+    /**
+     * Triggers a redirect to the 2FA setup route configured at routes.setup or throws an exception if the configuration is missing/incorrect
+     */
+    private function redirectToSetup(ComponentContext $componentContext): void
+    {
+        try {
+            $this->validateRouteValues($this->setupRouteValue);
+        } catch (\InvalidArgumentException $exception) {
+            throw new \RuntimeException('Missing/invalid routes.setup configuration: ' . $exception->getMessage(), 1550660178, $exception);
+        }
+        $this->redirect($componentContext, $this->setupRouteValue);
+    }
+
+    private function validateRouteValues(array $routeValues): void
+    {
+        $requiredRouteValues = ['@package', '@controller', '@action'];
+        foreach ($requiredRouteValues as $routeValue) {
+            if (!array_key_exists($routeValue, $routeValues)) {
+                throw new \InvalidArgumentException(sprintf('Missing "%s" route value', $routeValue), 1550660039);
+            }
+        }
+    }
+
+    private  function redirect(ComponentContext $componentContext, array $routeValues): void
+    {
+        /** @var HttpRequest $httpRequest */
+        $httpRequest = $componentContext->getHttpRequest();
+        $actionRequest = new ActionRequest($httpRequest);
+        $uriBuilder = new UriBuilder();
+        $uriBuilder->setRequest($actionRequest);
+        $redirectUrl = $uriBuilder->setCreateAbsoluteUri(true)->setFormat('html')->build($routeValues);
+
+        $componentContext->replaceHttpResponse($componentContext->getHttpResponse()->withStatus(303)->withHeader('Location', $redirectUrl));
+        $componentContext->setParameter(ComponentChain::class, 'cancel', true);
+    }
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -28,6 +28,13 @@ Yeebase:
 
 Neos:
   Flow:
+    http:
+      chain:
+        'process':
+          chain:
+            'Yeebase.TwoFactorAuthentication:Redirect':
+              position: 'after dispatching'
+              component: 'Yeebase\TwoFactorAuthentication\Http\RedirectComponent'
     persistence:
       doctrine:
         migrations:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "Two-Factor-Authentication (2FA) for Neos Flow",
   "license": "MIT",
   "require": {
-    "neos/flow": "^5.2",
+    "neos/flow": "^5.3",
     "pragmarx/google2fa": "^4.0",
     "bacon/bacon-qr-code": "^2.0"
   },


### PR DESCRIPTION
The HTTP foundation of Flow has been changed profoundly between
5.2 and 5.3. This adjusts the 2FA mechanism accordingly by using
a HTTP component to trigger redirects to the 2FA login/setup
instead of triggering the redirect from the authentication provider
itself (which didn't work any longer)