### PR TITLE
FEATURE: Optionally configurable application name.

### DIFF
--- a/Classes/Service/TwoFactorAuthenticationService.php
+++ b/Classes/Service/TwoFactorAuthenticationService.php
@@ -98,10 +98,10 @@ final class TwoFactorAuthenticationService
      * Generates a QR Code for the configured application name and the specified $holder
      * The QR Code can be used to activate 2FA, @see enableTwoFactorAuthentication()
      */
-    public function generateActivationQrCode(string $holder): ActivationQrCode
+    public function generateActivationQrCode(string $holder, string $applicationName = ''): ActivationQrCode
     {
         $secret = $this->generateSecret();
-        $qrCodeUrl = $this->google2FA->getQRCodeUrl($this->applicationName, $holder, $secret->toString());
+        $qrCodeUrl = $this->google2FA->getQRCodeUrl($applicationName === '' ? $this->applicationName : $applicationName, $holder, $secret->toString());
         return ActivationQrCode::fromSecretAndUrl($secret, $qrCodeUrl);
     }
 


### PR DESCRIPTION
Hi,

we are introducing 2FA for our users as an option and offer our application in a white-labeled version. For that we wanted to have the chance to specify a different applicationName than the one configured in the Settings.yaml.
This is what this pull request does. There's an optional parameter called applicationName for the generateActivationQrCode function that is used instead of the setting if it is specified.

Let me know what you think.
We're currently testing the 2FA stuff but that part works pretty well.

Thanks,
David