### PR TITLE
!!![TASK] Compatibility with Flow 6.0

### DIFF
--- a/Classes/Security/RequestPattern/ExcludeTwoFactorAuthenticationSetup.php
+++ b/Classes/Security/RequestPattern/ExcludeTwoFactorAuthenticationSetup.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 namespace Yeebase\TwoFactorAuthentication\Security\RequestPattern;
 
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Mvc\RequestInterface;
 use Neos\Flow\Security\RequestPatternInterface;
 use Neos\Flow\Annotations as Flow;
 
@@ -19,7 +18,7 @@ final class ExcludeTwoFactorAuthenticationSetup implements RequestPatternInterfa
      */
     protected $setupRoute;
 
-    public function matchRequest(RequestInterface $request): bool
+    public function matchRequest(ActionRequest $request): bool
     {
         if (!$request instanceof ActionRequest) {
             return true;

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "Two-Factor-Authentication (2FA) for Neos Flow",
   "license": "MIT",
   "require": {
-    "neos/flow": "^5.3",
+    "neos/flow": "^6.0",
     "pragmarx/google2fa": "^4.0",
     "bacon/bacon-qr-code": "^2.0"
   },


### PR DESCRIPTION
Makes the `matchRequest`-method compatible to Neos 5.1 and
sets the new flow-Version.